### PR TITLE
feat: Add dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(npm)"
+      prefix-development: "chore(npm-dev)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/label-dependabot.yml
+++ b/.github/workflows/label-dependabot.yml
@@ -1,0 +1,27 @@
+---
+name: Label Dependabot PRs
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  dependabot:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'elidholm/coding-bookshelf'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Add a label for all production dependencies
+        if: ${{ steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
+        run: gh pr edit "$PR_URL" --add-label "production"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled weekly automated dependency updates for npm packages and GitHub Actions via Dependabot, with distinct commit prefixes for production vs. development updates to improve PR clarity and maintenance cadence.
  * Added an automation that labels Dependabot pull requests affecting direct production dependencies with “production,” running only on Dependabot PRs to streamline triage and review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->